### PR TITLE
Added SonarC# analyzer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,7 @@ Awesome open source analyzers, code fixes, and refactorings.
 - [Refactoring Essentials for Visual Studio](https://github.com/icsharpcode/RefactoringEssentials/) - Refactorings, analyzers and code fixes for C# and VB.NET.
 - [Roslyn Clr Heap Allocation Analyzer](https://github.com/Microsoft/RoslynClrHeapAllocationAnalyzer) - A C# heap allocation analyzer that can detect explicit and many implicit allocations like boxing, display classes a.k.a closures, implicit delegate creations, etc.
 - [Roslynator](https://github.com/JosefPihrt/Roslynator) - A collection of 190+ analyzers and 190+ refactorings for C#. Covers coding style, code readability and simplification, removing redundancies, fixing compiler errors and many more.
+- [SonarC#](https://github.com/SonarSource/sonar-csharp) - SonarC# is a static code analyzer for C# language used as an extension for the SonarQube platform. 
 - [StyleCop Analyzers for the .NET Compiler Platform](https://github.com/DotNetAnalyzers/StyleCopAnalyzers) - A port of StyleCop rules to Roslyn.
 - [VSDiagnostics](https://github.com/Vannevelj/VSDiagnostics) - A collection of code-quality analyzers. Covers usages of async methods, flags enums, best practices in exception handling as well as many other code-quality checks.
 


### PR DESCRIPTION
 SonarC# is a static code analyzer for C# language used as an extension for the SonarQube platform. 

https://github.com/SonarSource/sonar-csharp