### PR TITLE
add enum source generator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,7 @@ Awesome (but mostly experimental at the moment, because .NET 5.0 and C# 9.0 are 
 - [StructPacker](https://github.com/RudolfKurka/StructPacker) - Low-level, lightweight and performance-focused serializer for C# struct types. Auto-generates C# serialization code to achieve peak runtime performance and efficiency.
 - [Svg to C# Source Generators](https://github.com/wieslawsoltes/SourceGenerators) - SVG to C# compiler. Compiles SVG drawing markup to C# using [SkiaSharp](https://github.com/mono/SkiaSharp) as rendering engine.
 - [WrapperValueObject](https://github.com/martinothamar/WrapperValueObject) - Creates boilerplate free wrappers around types. Especially useful for creating [strongly typed wrappers around primitive types](https://andrewlock.net/series/using-strongly-typed-entity-ids-to-avoid-primitive-obsession/).
+- [Supernova.Enum.Generators](https://github.com/EngRajabi/Enum.Source.Generator) - A C# source generator to create an enumeration class from an enum type. With this package, you can work on enums very, very fast without using reflection.
 
 ## Blog Posts and Articles
 Awesome blog posts and online articles covering various topics like performance, Roslyn history, internals and similar.


### PR DESCRIPTION
I added to the Enum Source Generator project that works with enums in Compile-time and is very, very fast.
[Project link](https://github.com/EngRajabi/Enum.Source.Generator)

![Supernova Enum Generators](https://user-images.githubusercontent.com/10164223/170815772-700e13b9-cff5-4b2a-9d50-6d842c19961d.png)

